### PR TITLE
Allow other acceptable characters for mobile number

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -381,20 +381,19 @@
             prefix="+"
             hint="Enter country code"
             min = "1"
-            pattern="^[0-9]+$"
             required
           ></v-text-field>
         </v-col>
         <v-col md="6" >
           <v-text-field
             v-model="userMobileNumber"
-            type="number"
+            type="text"
             hint="Enter researcher phone number"
             required
             min = "1"
-            pattern="^[0-9]+$">
+            >
             <template #label>
-                <span>Phone Number (only digits)<span style='color: red;'> *</span></span>
+                <span>Phone Number<span style='color: red;'> *</span></span>
             </template>
           </v-text-field>
         </v-col>
@@ -453,6 +452,8 @@ export default {
           'Fourth',
           'Fifth',
         ],
+        countryCodePattern: /\d+/g,
+        mobileNumberPattern: /\(?\d{1,3}\)?[- ]?\d{3}[- ]?\d{4}$/g
       }
     },
   components: {
@@ -528,14 +529,28 @@ export default {
     console.log(this.user)
   },
   methods:{
+    validateNumber() {
+      if (this.userCountryCode|| this.userMobileNumber) { // if countryCode or mobileNumber was entered ensure it matches the expected format
+        var match1 = this.userCountryCode.match(this.countryCodePattern)
+        var match2 = this.userMobileNumber.match(this.mobileNumberPattern)
+        return match1 && (this.userCountryCode === match1[0]) && match2 && (this.userMobileNumber === match2[0]);
+      }
+      return true// an empty countryCode and mobileNumber at the same time is allowed
+    },
     async addFields(){
       if (!this.$auth.loggedIn) {
         this.$router.push('/login')
       } else {
         this.dialogMessage = ''
         this.localuser.position = this.userPosition
-        this.localuser.countryCode = this.userCountryCode
-        this.localuser.mobileNumber = this.userMobileNumber
+        let isValidNumber = this.validateNumber()
+        if (!isValidNumber) {
+          this.dialogMessage = 'Please enter valid charaters for Mobile Number'
+        }
+        else{
+          this.localuser.countryCode = this.userCountryCode
+          this.localuser.mobileNumber = this.userMobileNumber.replace(/\D/g, '');
+        }
         this.localuser.name = this.userName
         this.localuser.email = this.userEmail
         this.localuser.userOTP = this.userOTP.length == 0 && this.otpSent ? 'undefined' : this.userOTP
@@ -554,7 +569,7 @@ export default {
           return
         }
 
-        if(this.localuser.position && this.userAffiliation.length && this.localuser.email && this.localuser.name && this.localuser.mobileNumber && this.localuser.countryCode){
+        if(this.localuser.position && this.userAffiliation.length && this.localuser.email && this.localuser.name && this.localuser.mobileNumber && this.localuser.countryCode && isValidNumber){
           this.dialog=false
         }
 

--- a/pages/profile/index.vue
+++ b/pages/profile/index.vue
@@ -74,12 +74,12 @@
                   <v-col cols="12" md="10">
                   <v-text-field
                     v-model="localuser.mobileNumber"
-                    type="number"
+                    type="text"
                     min = "1"
                     hint="Enter researcher phone number"
                   >
                     <template #label>
-                        <span>Phone Number (only digits)</span>
+                        <span>Phone Number</span>
                     </template>
                   </v-text-field>
                   </v-col>
@@ -283,7 +283,8 @@ export default {
       userUpdateIncomplete: false,
       emailOnPageLoad: '',
       publicKeyPatternRegex: /^(ssh-(ed25519|rsa|dss|ecdsa)) AAAA(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=|[A-Za-z0-9+\/]{4})( [^@]+@[^@]+)?$/,
-      numberPattern: /\d+/g
+      countryCodePattern: /\d+/g,
+      mobileNumberPattern: /\(?\d{1,3}\)?[- ]?\d{3}[- ]?\d{4}$/g
     }
   },
   computed: {
@@ -384,8 +385,8 @@ export default {
     },
     validateNumber() {
       if (this.localuser.countryCode || this.localuser.mobileNumber) { // if countryCode or mobileNumber was entered ensure it matches the expected format
-        var match1 = this.localuser.countryCode.match(this.numberPattern)
-        var match2 = this.localuser.mobileNumber.match(this.numberPattern)
+        var match1 = this.localuser.countryCode.match(this.countryCodePattern)
+        var match2 = this.localuser.mobileNumber.match(this.mobileNumberPattern)
         return match1 && (this.localuser.countryCode === match1[0]) && match2 && (this.localuser.mobileNumber === match2[0]);
       }
       return true // an empty countryCode and mobileNumber at the same time is allowed
@@ -413,6 +414,8 @@ export default {
           this.profileCardMessage = 'Both country code and mobile number must be a number.'
           return
         }
+        //removing spaces, parenthesis and other acceptable characters and sending only digits.
+        this.localuser.mobileNumber = this.localuser.mobileNumber.replace(/\D/g, '');
         
         this.userUpdateIncomplete = true
         this.localuser.email = this.userEmail


### PR DESCRIPTION
Previously, the mobile number field on the Profile Page and in the dialog box strictly accepted only digits. The changes have modified this restriction, enabling the inclusion of special characters such as parentheses , hyphens , and spaces.