### PR TITLE
Issue search optimization

### DIFF
--- a/components/SearchCard.vue
+++ b/components/SearchCard.vue
@@ -302,31 +302,31 @@ export default {
       } else {
         let onSubmitKeyword = this.search
 
-        let payload = {
-          keywords: this.search,
-          page: this.page,
-          items_per_page: this.limit,
-          type: this.advanced.types
-        }
+        // let payload = {
+        //   keywords: this.search,
+        //   page: this.page,
+        //   items_per_page: this.limit,
+        //   type: this.advanced.types
+        // }
 
         this.author ? (payload['author'] = this.author) : false
         this.owner ? (payload['owner'] = this.owner) : false
         this.organization ? (payload['organization'] = this.organization) : false
         this.advanced.badge_ids ? (payload['badge_id'] = this.advanced.badge_ids) : false
-        let response = await this.$artifactSearchCategoryEndpoint.index({
-          ...payload
-        })
+        // let response = await this.$artifactSearchCategoryEndpoint.index({
+        //   ...payload
+        // })
 
         // Only proceed if the keyword collected before artifactSearchCategoryEndpoint's call is the same as the current search keyword
         if (onSubmitKeyword == this.search) {
-          let data = []
+          // let data = []
           this.selectedCategories = []
           this.categories = []
-          for (let i in response.categoryDict){
-            data.push([i, response.categoryDict [i].count])
-          }
-          this.categories = data
-          this.selectedCategories = new Array(this.categories.length).fill(true);
+          // for (let i in response.categoryDict){
+          //   data.push([i, response.categoryDict [i].count])
+          // }
+          // this.categories = data
+          // this.selectedCategories = new Array(this.categories.length).fill(true);
           this.getArtifacts()
         }
       }
@@ -375,23 +375,32 @@ export default {
         this.owner ? (payload['owner'] = this.owner) : false
         this.organization ? (payload['organization'] = this.organization) : false
         this.advanced.badge_ids ? (payload['badge_id'] = this.advanced.badge_ids) : false
-
-        const categoryNames = Object.values(this.categories).map(category => category[0]);
-        const selectedCategoryNames = categoryNames.filter((category, index) => this.selectedCategories[index]);
-        payload['category'] = selectedCategoryNames
+        if (this.categories) {
+          const categoryNames = Object.values(this.categories).map(category => category[0]);
+          const selectedCategoryNames = categoryNames.filter((category, index) => this.selectedCategories[index]);
+          payload['category'] = selectedCategoryNames
+        }
         this.$store.commit('artifacts/SET_LOADING', true)
         this.$store.commit('artifacts/SET_SEARCH', payload.keywords)
         let response = await this.$artifactSearchEndpoint.index({
           ...payload
         })
+        let data = []
+        // this.selectedCategories = []
+        // this.categories = []
+        for (let i in response.category_dict){
+          data.push([i, response.category_dict [i].count])
+        }
+        this.categories = data
+        this.selectedCategories = new Array(this.categories.length).fill(true);
 
         if (typeof response !== 'undefined') {
           
           // Only proceed if the keyword collected before artifactSearchEndpoint's call is the same as the current search keyword
           if (getArtifactsKeyword == this.search) {
-            console.log("Setting artifacts", response)
+            console.log("Setting artifacts", response.artifact_dict.artifacts)
 
-            this.$store.commit('artifacts/SET_ARTIFACTS', response)
+            this.$store.commit('artifacts/SET_ARTIFACTS', response.artifact_dict.artifacts)
           }
         }
         this.$store.commit('artifacts/SET_LOADING', false)        

--- a/components/SearchCard.vue
+++ b/components/SearchCard.vue
@@ -300,16 +300,10 @@ export default {
       if (this.related && this.search.trim() === '') {
         this.$store.dispatch('artifacts/fetchRelatedArtifacts', this.artifact)
       } else {
-        let onSubmitKeyword = this.search
-
-        // Only proceed if the keyword collected before artifactSearchCategoryEndpoint's call is the same as the current search keyword
-        if (onSubmitKeyword == this.search) {
-
-          this.selectedCategories = []
-          this.categories = []
-          
-          this.getArtifacts()
-        }
+        // We reset selectedCategories and categories only when we do onSubmit (getArtifacts could be called even after a keyword submission (page change, category filtering))
+        this.selectedCategories = []
+        this.categories = []
+        this.getArtifacts()
       }
       this.searchInterval = setTimeout(() => {
         if (!this.searchLoading) {
@@ -355,6 +349,7 @@ export default {
       this.organization ? (payload['organization'] = this.organization) : false
       this.advanced.badge_ids ? (payload['badge_id'] = this.advanced.badge_ids) : false
 
+      // If we already have retrieved categories then we can check the list of switches to see the selectedCategoryNames upon calling getArtifacts
       if (this.categories.length > 0) {
         const categoryNames = Object.values(this.categories).map(category => category[0]);
         const selectedCategoryNames = categoryNames.filter((category, index) => this.selectedCategories[index]);
@@ -371,6 +366,7 @@ export default {
         ...payload
       })
 
+      // If categories is empty then we must populate it for the first time
       if (this.categories.length == 0) {
         let data = []
         for (let i in response.category_dict){
@@ -381,7 +377,6 @@ export default {
       } 
 
       if (typeof response !== 'undefined') {
-        
         // Only proceed if the keyword collected before artifactSearchEndpoint's call is the same as the current search keyword
         if (getArtifactsKeyword == this.search) {
           console.log("Setting artifacts", response.artifact_dict)

--- a/plugins/repository.js
+++ b/plugins/repository.js
@@ -25,12 +25,6 @@ export default (ctx, inject) => {
     repositoryWithAxios('kg/' + 'artifact/search')
   )
 
-  //artifact category end point
-  inject(
-    'artifactSearchCategoryEndpoint',
-    repositoryWithAxios('kg/' + 'artifact/searchCategory')
-  )
-
   inject(
     'artifactRecommendationEndpoint',
     repositoryWithAxios('kg/' + 'artifact/recommendation')

--- a/store/artifacts.js
+++ b/store/artifacts.js
@@ -107,7 +107,7 @@ export const actions = {
       ...payload
     })
     if (typeof response !== 'undefined') {
-      console.log(response)
+      console.log("Setting artifacts: ", response)
       commit('SET_ARTIFACTS', response.artifact_dict)
     }
     commit('SET_LOADING', false)

--- a/store/artifacts.js
+++ b/store/artifacts.js
@@ -108,7 +108,7 @@ export const actions = {
     })
     if (typeof response !== 'undefined') {
       console.log(response)
-      commit('SET_ARTIFACTS', response)
+      commit('SET_ARTIFACTS', response.artifact_dict)
     }
     commit('SET_LOADING', false)
   },


### PR DESCRIPTION
I worked on improving the search feature by removing the dependency on the artifact category endpoint, which previously enforced 2 round-trips for every search (one to get the category name and another to get the artifacts). Note that both round-trips were equally expensive so collapsing it into one endpoint has significantly improved search time.