### PR TITLE
Added a null check for affiliation input

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -630,7 +630,7 @@ export default {
       }
     },
     onAffiliationInput(value) {
-      if (value.length > 0 || this.userAffiliation.length > 0) {
+      if (value && value.length > 0) {
         this.menuProps.value = true; // Show the menu if there's input
       } else {
         this.menuProps.value = false; // Hide the menu if input is cleared


### PR DESCRIPTION
This resolves the following issue reported by David Balenson:
"Yesterday, I tried to create a Comunda account. I used my github login. When asked to complete my profile, I ran into an issue selecting my organization – after selecting USC Information Sciences Institute, I could not escape the list of organizations and continue completing my profile."